### PR TITLE
Optimization wrappers

### DIFF
--- a/Finite_approx/GenericOptimization.ipynb
+++ b/Finite_approx/GenericOptimization.ipynb
@@ -15,8 +15,10 @@
     "import matplotlib.pyplot as plt\n",
     "from copy import deepcopy\n",
     "\n",
-    "from valez_finite_VI_lib import *\n",
-    "from generic_optimization_lib import *"
+    "from scipy import optimize\n",
+    "\n",
+    "from valez_finite_VI_lib import initialize_parameters, generate_data, compute_elbo\n",
+    "from generic_optimization_lib import unpack_params, pack_params"
    ]
   },
   {
@@ -33,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {
     "collapsed": true
    },
@@ -43,7 +45,7 @@
     "\n",
     "alpha = 10 # IBP parameter\n",
     "\n",
-    "Num_samples = 5000 # sample size\n",
+    "Num_samples = 2000 # sample size\n",
     "D = 2 # dimension\n",
     "# so X will be a N\\times D matrix\n",
     "\n",
@@ -58,12 +60,14 @@
     "K_approx = deepcopy(K_inf) # variational truncation\n",
     "\n",
     "tau, nu, phi_mu, phi_var = initialize_parameters(Num_samples, D, K_approx)\n",
-    "nu_init = np.round(nu * (nu >= 0.9) + nu * (nu <= 0.1)) + nu * (nu >= 0.1) * (nu <= 0.9)\n"
+    "nu_init = np.round(nu * (nu >= 0.9) + nu * (nu <= 0.1)) + nu * (nu >= 0.1) * (nu <= 0.9)\n",
+    "params = pack_params(deepcopy(tau), deepcopy(phi_mu), deepcopy(phi_var), deepcopy(nu))\n",
+    "params_init = deepcopy(params)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {
     "collapsed": true
    },
@@ -78,11 +82,62 @@
     "        self.sigmas = {'eps': sigma_eps, 'A': sigma_A}\n",
     "        #self.nu = np.empty((X.shape[0], K_approx))\n",
     "        \n",
-    "    def wrapped_elbo(self, params):\n",
+    "    def wrapped_kl(self, params, verbose=False):\n",
     "        tau, phi_mu, phi_var, nu = \\\n",
     "            unpack_params(params, self.data_shape['K'], self.data_shape['D'], self.data_shape['N'])\n",
-    "        return compute_elbo(tau, nu, phi_mu, phi_var, self.X, self.sigmas, self.alpha)[0]\n",
+    "        elbo = compute_elbo(tau, nu, phi_mu, phi_var, self.X, self.sigmas, self.alpha)[0]\n",
+    "        if verbose:\n",
+    "            print -1 * elbo\n",
+    "        return -1 * elbo\n",
     "        \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4858169.677175656"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_set = DataSet(X, K_approx, alpha, sigma_eps, sigma_A)\n",
+    "data_set.wrapped_kl(params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[-1708.20647253   173.71298395 -2738.82010207 ...,    35.92961572\n",
+      "    60.1122894      3.58939   ]\n",
+      "[ -4534516.47123467   1739212.97942215 -10179841.1094394  ...,\n",
+      "  12136800.26632632  13880040.31309656   3663558.89338671]\n"
+     ]
+    }
+   ],
+   "source": [
+    "get_kl_grad = grad(data_set.wrapped_kl)\n",
+    "get_kl_hvp = hessian_vector_product(data_set.wrapped_kl)\n",
+    "\n",
+    "kl_grad = get_kl_grad(params)\n",
+    "kl_hvp = get_kl_hvp(params, kl_grad)\n",
+    "\n",
+    "print kl_grad\n",
+    "print kl_hvp"
    ]
   },
   {
@@ -91,40 +146,149 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "-17133393.433775857"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4858169.67718\n",
+      "4507580.4666\n",
+      "3866133.91997\n",
+      "2821738.85538\n",
+      "1683994.95868\n",
+      "1572440.16592\n",
+      "1385585.86464\n",
+      "1058080.17789\n",
+      "713115.448692\n",
+      "673867.254049\n",
+      "652979.423718\n",
+      "72339145292.3\n",
+      "525871.998052\n",
+      "31082012003.7\n",
+      "482562.78367\n",
+      "714152.736789\n",
+      "458236.23201\n",
+      "429368.983794\n",
+      "119967645.478\n",
+      "408306.904637\n",
+      "386204.196115\n",
+      "169542542.653\n",
+      "367182.946403\n",
+      "343507.209254\n",
+      "859416108.077\n",
+      "332680.279592\n",
+      "324780.309084\n",
+      "307485.813777\n",
+      "283213.501556\n",
+      "282515.817251\n",
+      "286629.181175\n",
+      "275846.041605\n",
+      "266747.367467\n",
+      "261015.709604\n",
+      "253622.764708\n",
+      "1499278.5144\n",
+      "245355.467608\n",
+      "237294.314446\n",
+      "231402.208132\n",
+      "223678.672573\n",
+      "220216.055715\n",
+      "221615.341947\n",
+      "217173.519537\n",
+      "215506.618202\n",
+      "211280.097351\n",
+      "207516.384078\n",
+      "206734.667234\n",
+      "205353.683161\n",
+      "204039.906242\n",
+      "198806.266592\n",
+      "208424.378821\n",
+      "196616.541605\n",
+      "195293.590273\n",
+      "192710.009355\n",
+      "191000.225662\n",
+      "186758.43645\n",
+      "185592.614838\n",
+      "181473.428782\n",
+      "179311.92317\n",
+      "176507.956275\n",
+      "171955.664224\n",
+      "168771.582119\n",
+      "164748.648141\n",
+      "163546.096531\n",
+      "160510.48432\n",
+      "156485.361121\n",
+      "153460.53815\n",
+      "150639.49267\n",
+      "153115.803271\n",
+      "150547.302024\n",
+      "150160.572957\n",
+      "149916.470282\n",
+      "149239.047513\n",
+      "147802.073142\n",
+      "146965.809769\n",
+      "146645.488701\n",
+      "144907.85863\n",
+      "143876.749676\n",
+      "142400.87964\n",
+      "141252.792456\n",
+      "140278.776473\n",
+      "137099.590059\n",
+      "154694.140503\n",
+      "144148.991359\n",
+      "136342.774695\n",
+      "136070.482323\n",
+      "135657.652193\n",
+      "135055.229504\n",
+      "134258.030254\n",
+      "132989.165165\n",
+      "132629.391878\n",
+      "130564.09875\n",
+      "130097.135155\n",
+      "130568.663408\n",
+      "129589.883886\n",
+      "128643.353602\n",
+      "127539.526886\n",
+      "127380.81951\n",
+      "127040.028416\n",
+      "126638.033052\n",
+      "125521.28467\n",
+      "Warning: Maximum number of iterations has been exceeded.\n",
+      "         Current function value: 125521.284670\n",
+      "         Iterations: 100\n",
+      "         Function evaluations: 101\n",
+      "         Gradient evaluations: 85\n",
+      "         Hessian evaluations: 0\n"
+     ]
     }
    ],
    "source": [
-    "params = pack_params(deepcopy(tau), deepcopy(phi_mu), deepcopy(phi_var), deepcopy(nu))\n",
-    "data_set = DataSet(X, K_approx, alpha, sigma_eps, sigma_A)\n",
-    "data_set.wrapped_elbo(params)"
+    "vb_opt = optimize.minimize(\n",
+    "    lambda params: data_set.wrapped_kl(params, verbose=True),\n",
+    "    params_init, method='trust-ncg', jac=get_kl_grad, hessp=get_kl_hvp,\n",
+    "    tol=1e-6, options={'maxiter': 100, 'disp': True, 'gtol': 1e-6 })\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[  2.33484173e+03   1.10801349e+04   9.87794660e+02 ...,  -2.07693646e+01\n",
-      "  -2.61558804e+00   6.02003778e+01]\n"
+      "[[ 7.27434354 -2.006652  ]\n",
+      " [ 8.3221905  -1.20240182]\n",
+      " [ 8.55562752 -0.59554079]]\n",
+      "[[ 13.17491681  -7.83796064]\n",
+      " [  0.1543092    0.97045299]\n",
+      " [ 10.94654306   3.54649255]]\n"
      ]
     }
    ],
    "source": [
-    "elbo_grad = grad(data_set.wrapped_elbo)\n",
-    "elbo_grad = elbo_grad(params)\n",
-    "print elbo_grad"
+    "tau, phi_mu, phi_var, nu = unpack_params(vb_opt.x, D=D, K_approx=K_approx, Num_samples=Num_samples)\n",
+    "print phi_mu.transpose()\n",
+    "print A"
    ]
   }
  ],

--- a/Finite_approx/GenericOptimization.ipynb
+++ b/Finite_approx/GenericOptimization.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import autograd.numpy as np\n",
+    "import autograd.scipy as sp\n",
+    "from autograd.scipy import special\n",
+    "from autograd import grad, hessian, hessian_vector_product\n",
+    "import matplotlib.pyplot as plt\n",
+    "from copy import deepcopy\n",
+    "\n",
+    "from valez_finite_VI_lib import *\n",
+    "from generic_optimization_lib import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def check_approx_eq(x, y, tol=1e-12):\n",
+    "    return np.max(np.abs(x - y)) < tol"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "np.random.seed(12321) # this is a seed where VI works well\n",
+    "\n",
+    "alpha = 10 # IBP parameter\n",
+    "\n",
+    "Num_samples = 5000 # sample size\n",
+    "D = 2 # dimension\n",
+    "# so X will be a N\\times D matrix\n",
+    "\n",
+    "sigma_A = 100\n",
+    "\n",
+    "sigma_eps = .1 # variance of noise\n",
+    "\n",
+    "K_inf = 3 # take to be large for a good approximation to the IBP\n",
+    "\n",
+    "Pi, Z, mu, A, X = generate_data(Num_samples, D, K_inf, sigma_A, sigma_eps)\n",
+    "\n",
+    "K_approx = deepcopy(K_inf) # variational truncation\n",
+    "\n",
+    "tau, nu, phi_mu, phi_var = initialize_parameters(Num_samples, D, K_approx)\n",
+    "nu_init = np.round(nu * (nu >= 0.9) + nu * (nu <= 0.1)) + nu * (nu >= 0.1) * (nu <= 0.9)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "class DataSet(object):\n",
+    "    def __init__(self, X, K_approx, alpha, sigma_eps, sigma_A):\n",
+    "        self.X = X\n",
+    "        self.K_approx = K_approx\n",
+    "        self.alpha = alpha\n",
+    "        self.data_shape = {'D': X.shape[1], 'N': X.shape[0] , 'K':K_approx}\n",
+    "        self.sigmas = {'eps': sigma_eps, 'A': sigma_A}\n",
+    "        #self.nu = np.empty((X.shape[0], K_approx))\n",
+    "        \n",
+    "    def wrapped_elbo(self, params):\n",
+    "        tau, phi_mu, phi_var, nu = \\\n",
+    "            unpack_params(params, self.data_shape['K'], self.data_shape['D'], self.data_shape['N'])\n",
+    "        return compute_elbo(tau, nu, phi_mu, phi_var, self.X, self.sigmas, self.alpha)[0]\n",
+    "        \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-17133393.433775857"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "params = pack_params(deepcopy(tau), deepcopy(phi_mu), deepcopy(phi_var), deepcopy(nu))\n",
+    "data_set = DataSet(X, K_approx, alpha, sigma_eps, sigma_A)\n",
+    "data_set.wrapped_elbo(params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[  2.33484173e+03   1.10801349e+04   9.87794660e+02 ...,  -2.07693646e+01\n",
+      "  -2.61558804e+00   6.02003778e+01]\n"
+     ]
+    }
+   ],
+   "source": [
+    "elbo_grad = grad(data_set.wrapped_elbo)\n",
+    "elbo_grad = elbo_grad(params)\n",
+    "print elbo_grad"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Finite_approx/cavi_unittest.py
+++ b/Finite_approx/cavi_unittest.py
@@ -58,24 +58,6 @@ sigma_A = 100
 
 sigma_eps = 1 # variance of noise
 
-# Draw Z from truncated stick breaking process
-# for k in range(k_inf):
-#     Pi[k] = np.random.beta(alpha/k_inf,1)
-#     for n in range(num_samples):
-#         Z[n,k] = np.random.binomial(1,Pi[k])
-
-# Draw A from multivariate normal
-# A = np.random.multivariate_normal(mu, sigma_A*np.identity(D), k_approx)
-#A = np.random.normal(0, np.sqrt(sigma_A), (k_approx,D))
-
-# draw noise
-# epsilon = np.random.multivariate_normal(np.zeros(D), sigma_eps*np.identity(D), num_samples)
-#epsilon = np.random.normal(0, np.sqrt(sigma_eps), (num_samples, D))
-
-# the observed data
-#X = np.dot(Z,A) + epsilon
-
-
 Pi, Z, mu, A, X = generate_data(num_samples, D, k_inf, sigma_A, sigma_eps)
 
 k_approx = k_inf # variational truncation
@@ -103,7 +85,7 @@ class TestCaviUpdates(unittest.TestCase):
         E_log_pi1 = sp.special.digamma(tau[:,0]) - sp.special.digamma(tau[:,0] + tau[:,1])
         E_log_pi2 = sp.special.digamma(tau[:,1]) - sp.special.digamma(tau[:,0] + tau[:,1])
 
-
+        digamma_tau = sp.special.digamma(tau)
         for n in range(num_samples):
             for k in range(k_approx):
 
@@ -112,7 +94,7 @@ class TestCaviUpdates(unittest.TestCase):
                                E_log_pi1, E_log_pi2, data_shape, sigmas, X, alpha)
                 nu_AG = 1/(1 + np.exp(-script_V_AG))
 
-                nu_updates(tau, nu, phi_mu, phi_var, X, sigmas, n, k)
+                nu_updates(tau, nu, phi_mu, phi_var, X, sigmas, n, k, digamma_tau)
 
                 # print(np.abs(nu[n,k] - nu_AG[n,k]))
                 self.assertAlmostEqual(nu[n,k] , nu_AG[n,k])

--- a/Finite_approx/cavi_unittest.py
+++ b/Finite_approx/cavi_unittest.py
@@ -1,4 +1,6 @@
-#!/usr/bin/python
+#!/usr/bin/python3
+
+# Alarmingly, this fails with python2!
 
 # First unit test-- check CAVI updates
 
@@ -9,72 +11,44 @@ import autograd.numpy as np
 import autograd.scipy as sp
 from copy import deepcopy
 
-def exp_log_likelihood(nu_moment, phi_moment1, phi_moment2, \
-                       E_log_pi1, E_log_pi2, data_shape, sigmas, X, alpha):
-
-    sigma_eps = sigmas['eps']
-    sigma_A = sigmas['A']
-    D = data_shape['D']
-    N = data_shape['N']
-    K = data_shape['K']
-
-    beta_lh = (alpha/K - 1.)*np.sum(E_log_pi1)
-    bern_lh = np.sum(np.dot(nu_moment[n,:], E_log_pi1) \
-                            + np.dot(1.-nu_moment[n,:], E_log_pi2) for n in range(N))
-    Normal_A = -1/(2.*sigma_A) * np.sum(phi_moment2)
-
-    Normal_X_sum = 0
-    ## compute the data likelihood term
-    for n in range(N):
-        dum1 = 2.*np.sum(np.sum(nu_moment[n,i] * nu_moment[n,j] * np.dot(phi_moment1[:,i],phi_moment1[:,j]) \
-                                for i in range(j)) for j in range(K))
-        dum2 = np.dot(nu_moment[n,:] , phi_moment2 )
-
-        dum3 = -2. * np.dot(X[n,:], np.dot(phi_moment1, nu_moment[n,:]))
-
-        # dum4 = np.dot(X[n,:], X[n,:])
-        Normal_X_sum += dum1 + dum2 + dum3
-
-    Normal_X = -1/(2*sigma_eps)*Normal_X_sum
-
-    y = beta_lh + bern_lh + Normal_A + Normal_X
-    return(y)
+from scipy.stats import bernoulli
 
 # Draw Data
-num_samples = 10 # sample size
+Num_samples = 5 # sample size
 D = 2 # dimension
 # so X will be a n\times D matrix
 
-k_inf = 3 # take to be large for a good approximation to the IBP
-k_approx = k_inf
+K_inf = 3 # take to be large for a good approximation to the IBP
+K_approx = deepcopy(K_inf)
 
 alpha = 2 # IBP parameter
-# Pi = np.zeros(k_inf)
-# Z = np.zeros([num_samples,k_inf])
 
 # Parameters to draw A from MVN
-mu = np.zeros(D)
 sigma_A = 100
-
 sigma_eps = 1 # variance of noise
 
-Pi, Z, mu, A, X = generate_data(num_samples, D, k_inf, sigma_A, sigma_eps)
+Pi, Z, mu, A, X = generate_data(Num_samples, D, K_inf, sigma_A, sigma_eps)
 
-k_approx = k_inf # variational truncation
-tau, nu, phi_mu, phi_var = initialize_parameters(num_samples, D, k_approx)
-
-data_shape = {'D':D, 'N': num_samples , 'K':k_approx}
+Data_shape = {'D':D, 'N': Num_samples , 'K':K_approx}
 sigmas = {'eps': sigma_eps, 'A': sigma_A}
 
 
 class TestCaviUpdates(unittest.TestCase):
+    def test_silly(self):
+        self.assertEqual(2,2)
+        self.assertFalse(2==3)
+
+        for i in range(5):
+            self.assertEqual(i,i)
+
     def test_nu_updates(self):
         # initialization for cavi updates
-        tau = np.random.uniform(10,100,[k_approx,2])
-        nu = np.random.uniform(0,1,[num_samples,k_approx])
+        tau = np.random.uniform(10,100,[K_approx,2])
+        digamma_tau = sp.special.digamma(tau)
+        nu = np.random.uniform(0,1,[Num_samples,K_approx])
 
-        phi_mu = np.random.normal(0,1,[D,k_approx])
-        phi_var = np.ones(k_approx)
+        phi_mu = np.random.normal(0,1,[D,K_approx])
+        phi_var = np.ones(K_approx)
 
         # autodiff
         d_exp_log_LH = grad(exp_log_likelihood, 0)
@@ -85,27 +59,28 @@ class TestCaviUpdates(unittest.TestCase):
         E_log_pi1 = sp.special.digamma(tau[:,0]) - sp.special.digamma(tau[:,0] + tau[:,1])
         E_log_pi2 = sp.special.digamma(tau[:,1]) - sp.special.digamma(tau[:,0] + tau[:,1])
 
-        digamma_tau = sp.special.digamma(tau)
-        for n in range(num_samples):
-            for k in range(k_approx):
+
+        for n in range(Num_samples):
+            for k in range(K_approx):
 
                 nu_moment = deepcopy(nu)
                 script_V_AG = d_exp_log_LH(nu_moment, phi_moment1, phi_moment2, \
-                               E_log_pi1, E_log_pi2, data_shape, sigmas, X, alpha)
+                               E_log_pi1, E_log_pi2, Data_shape, sigmas, X, alpha)
                 nu_AG = 1/(1 + np.exp(-script_V_AG))
 
                 nu_updates(tau, nu, phi_mu, phi_var, X, sigmas, n, k, digamma_tau)
+
 
                 # print(np.abs(nu[n,k] - nu_AG[n,k]))
                 self.assertAlmostEqual(nu[n,k] , nu_AG[n,k])
 
     def test_tau_updates(self):
         # initialization for cavi updates
-        tau = np.random.uniform(10,100,[k_approx,2])
-        nu = np.random.uniform(0,1,[num_samples,k_approx])
+        tau = np.random.uniform(10,100,[K_approx,2])
+        nu = np.random.uniform(0,1,[Num_samples,K_approx])
 
-        phi_mu = np.random.normal(0,1,[D,k_approx])
-        phi_var = np.ones(k_approx)
+        phi_mu = np.random.normal(0,1,[D,K_approx])
+        phi_var = np.ones(K_approx)
 
         # calling autodiff
         d_tau1 = grad(exp_log_likelihood, 3)
@@ -120,9 +95,9 @@ class TestCaviUpdates(unittest.TestCase):
 
         # computing updates
         tau1_AG = d_tau1(nu_moment, phi_moment1, phi_moment2, \
-                               E_log_pi1, E_log_pi2, data_shape, sigmas, X, alpha) + 1
+                               E_log_pi1, E_log_pi2, Data_shape, sigmas, X, alpha) + 1
         tau2_AG = d_tau2(nu_moment, phi_moment1, phi_moment2, \
-                               E_log_pi1, E_log_pi2, data_shape, sigmas, X, alpha) + 1
+                               E_log_pi1, E_log_pi2, Data_shape, sigmas, X, alpha) + 1
         tau_AG = np.array([tau1_AG, tau2_AG])
 
         tau_updates(tau, nu, alpha)
@@ -135,13 +110,14 @@ class TestCaviUpdates(unittest.TestCase):
         #print(tau2_AG)
 
         self.assertTrue(np.allclose(tau, tau_AG.T))
+
     def test_phi_updates(self):
         # initialization for cavi updates
-        tau = np.random.uniform(10,100,[k_approx,2])
-        nu = np.random.uniform(0,1,[num_samples,k_approx])
+        tau = np.random.uniform(10,100,[K_approx,2])
+        nu = np.random.uniform(0,1,[Num_samples,K_approx])
 
-        phi_mu = np.random.normal(0,1,[D,k_approx])
-        phi_var = np.ones(k_approx)
+        phi_mu = np.random.normal(0,1,[D,K_approx])
+        phi_var = np.ones(K_approx)
 
         # calling autodiff
         d_phi1  = grad(exp_log_likelihood, 1)
@@ -152,22 +128,21 @@ class TestCaviUpdates(unittest.TestCase):
         E_log_pi1 = sp.special.digamma(tau[:,0]) - sp.special.digamma(tau[:,0] + tau[:,1])
         E_log_pi2 = sp.special.digamma(tau[:,1]) - sp.special.digamma(tau[:,0] + tau[:,1])
 
-
-
-        for k in range(k_approx):
+        for k in range(K_approx):
             nu_moment = deepcopy(nu)
             phi_moment1 = deepcopy(phi_mu)
             phi_moment2 = np.diag(np.dot(phi_mu.T, phi_mu) + D * phi_var)
 
             # compute autograd updates
             phi1_AG = d_phi1(nu_moment, phi_moment1, phi_moment2, \
-                               E_log_pi1, E_log_pi2, data_shape, sigmas, X, alpha)
+                               E_log_pi1, E_log_pi2, Data_shape, sigmas, X, alpha)
             phi2_AG = d_phi2(nu_moment, phi_moment1, phi_moment2, \
-                               E_log_pi1, E_log_pi2, data_shape, sigmas, X, alpha)
+                               E_log_pi1, E_log_pi2, Data_shape, sigmas, X, alpha)
 
             # convert to standard parametrization
             phi_var_AG = -1/(2.*phi2_AG)
             phi_mu_AG = np.dot(phi1_AG, np.diag(phi_var_AG))
+
 
             phi_updates(nu, phi_mu, phi_var, X, sigmas, k) # cavi updates
 
@@ -180,6 +155,36 @@ class TestCaviUpdates(unittest.TestCase):
 
             self.assertTrue(np.allclose(phi_mu_AG[:,k], phi_mu[:,k]))
             self.assertTrue(np.allclose(phi_var_AG[k], phi_var[k]))
+
+class TestElboComputation(unittest.TestCase):
+    # initialize variational parameters
+    tau = np.random.uniform(10,100,[K_approx,2])
+    nu = np.random.uniform(0,1,[Num_samples,K_approx])
+
+    phi_mu = np.random.normal(0,1,[D,K_approx])
+    phi_var = np.ones(K_approx)
+
+    z_test = np.zeros((Num_samples, K_approx, 10**4))
+    for n in range(Num_samples):
+        for k in range(K_approx):
+            z_test[n,k,:] = bernoulli.rvs(nu[n,k], 10**4)
+
+    A_test = np.zeros((K_approx, 2,10**4))
+    for k in range(K_approx):
+        for d in range(D):
+            A_test[k,d,:] = np.random.normal(phi_mu[d,k], sigma_A, 10**4)
+
+    Pi = 0
+
+    print(np.shape(A_test))
+    print(np.shape(z_test))
+
+    # compute elbo
+    [elbo,elbo_Term1,elbo_Term2,elbo_Term3,elbo_Term4,elbo_Term5,elbo_Term6,\
+         elbo_Term7] = compute_elbo(tau, nu, phi_mu, phi_var, X, sigmas, alpha)
+
+
+
 
 
 if __name__ == '__main__':

--- a/Finite_approx/generic_optimization_lib.py
+++ b/Finite_approx/generic_optimization_lib.py
@@ -1,0 +1,54 @@
+import autograd.numpy as np
+import autograd.scipy as sp
+
+
+def pack_tau(tau):
+    return np.log(tau).flatten()
+
+def unpack_tau(tau_packed, K_approx, D):
+    return np.exp(tau_packed).reshape((K_approx, D))
+
+def pack_phi_mu(phi_mu):
+    return phi_mu.flatten()
+
+def unpack_phi_mu(phi_mu_packed, K_approx, D):
+    return phi_mu_packed.reshape((D, K_approx))
+
+def pack_phi_var(phi_var):
+    return np.log(phi_var.flatten())
+
+def unpack_phi_var(phi_var_packed):
+    return np.exp(phi_var_packed)
+
+def pack_nu(nu):
+    return sp.special.logit(nu).flatten()
+
+def unpack_nu(nu_packed, Num_samples, K_approx):
+    return sp.special.expit(nu_packed).reshape(Num_samples, K_approx)
+
+def pack_params(tau, phi_mu, phi_var, nu):
+    return np.hstack([ pack_tau(tau), pack_phi_mu(phi_mu),
+                       pack_phi_var(phi_var), pack_nu(nu) ])
+
+def unpack_params(params, K_approx, D, Num_samples):
+    offset = 0
+
+    tau_size = K_approx * D
+    phi_mu_size = K_approx * D
+    phi_var_size = K_approx
+    nu_size = Num_samples * K_approx
+
+    assert len(params) == tau_size + phi_mu_size + phi_var_size + nu_size
+
+    tau = unpack_tau(params[offset:(offset + tau_size)], K_approx, D)
+    offset += tau_size
+
+    phi_mu = unpack_phi_mu(params[offset:(offset + phi_mu_size)], K_approx, D)
+    offset += phi_mu_size
+
+    phi_var = unpack_phi_var(params[offset:(offset + phi_var_size)])
+    offset += phi_var_size
+
+    nu = unpack_nu(params[offset:(offset + nu_size)], Num_samples, K_approx)
+
+    return tau, phi_mu, phi_var, nu

--- a/Finite_approx/generic_optimization_lib_unittest.py
+++ b/Finite_approx/generic_optimization_lib_unittest.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+
+import unittest
+from valez_finite_VI_lib import initialize_parameters
+from generic_optimization_lib import \
+    unpack_tau, unpack_phi_mu, unpack_phi_var, unpack_nu, \
+    pack_tau, pack_phi_mu, pack_phi_var, pack_nu, \
+    unpack_params, pack_params
+from copy import deepcopy
+
+import numpy as np
+
+
+class TestParameterPacking(unittest.TestCase):
+    def assert_allclose(self, x, y):
+        self.assertTrue(np.allclose(x, y))
+
+    def test_packing(self):
+        num_samples = 10
+        d = 2
+        k_approx = 3
+
+        tau, nu, phi_mu, phi_var = \
+            initialize_parameters(num_samples, d, k_approx)
+
+        self.assert_allclose(unpack_tau(pack_tau(tau), k_approx, d), tau)
+        self.assert_allclose(unpack_phi_mu(
+            pack_phi_mu(phi_mu), k_approx, d), phi_mu)
+        self.assert_allclose(unpack_phi_var(pack_phi_var(phi_var)), phi_var)
+        self.assert_allclose(unpack_nu(pack_nu(nu), num_samples, k_approx), nu)
+
+        params = pack_params(
+            deepcopy(tau), deepcopy(phi_mu), deepcopy(phi_var), deepcopy(nu))
+        tau0, phi_mu0, phi_var0, nu0 = unpack_params(
+            params, k_approx, d, num_samples)
+
+        self.assert_allclose(tau0, tau)
+        self.assert_allclose(phi_mu0, phi_mu)
+        self.assert_allclose(phi_var0, phi_var)
+        self.assert_allclose(nu0, nu)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Finite_approx/valez_finite_VI_lib.py
+++ b/Finite_approx/valez_finite_VI_lib.py
@@ -1,23 +1,14 @@
-# -*- coding: utf-8 -*-
 """
-Created on Mon Apr 17 11:10:41 2017
-
-@author: Haiying Liang
+@author: Runjing Liu
 """
 
 import autograd.numpy as np
 import autograd.scipy as sp
-#from scipy.special import betaln
-#import numpy as np
-#import scipy as sp
 
-# import scipy.special
 import matplotlib.pyplot as plt
 from copy import deepcopy
 import math
 
-
-# from beta_process_vb_lib import *
 
 # Data_shape: D,N,K
 
@@ -37,13 +28,6 @@ def phi_updates(nu, phi_mu, phi_var, X, sigmas, k):
         phi_dum1 = X[n, :] - np.dot(phi_mu, nu[n, :]) + nu[n, k] * phi_mu[:, k]
         phi_summation += nu[n,k]*phi_dum1
 
-        #    dum1 = 0
-        #    for l in range(K):
-        #        if (l != k):
-        #            dum1 += nu[n,l] * phi_mu[:,l]
-
-        #    phi_summation += nu[n,k] * (X[n,:] - dum1)
-
     phi_mu[:,k] = (1 / s_eps) * phi_summation\
         * (1 / s_A + np.sum(nu[:, k]) / s_eps)**(-1)
 
@@ -55,33 +39,11 @@ def nu_updates(tau, nu, phi_mu, phi_var, X, sigmas, n, k, digamma_tau):
     N = np.shape(X)[0]
     K = np.shape(phi_mu)[1]
 
-    #nu_term1 = sp.special.digamma(tau[k,0]) - sp.special.digamma(tau[k,1])
-
     nu_term1 = digamma_tau[k,0] - digamma_tau[k,1]
 
     nu_term2 = (1. / (2. * s_eps)) * (phi_var[k]*D + np.dot(phi_mu[:,k], phi_mu[:,k]))
 
     nu_term3 = (1./s_eps) * np.dot(phi_mu[:, k], X[n, :] - np.dot(phi_mu, nu[n, :]) + nu[n,k] * phi_mu[:, k])
-
-    #if k==4 and n==3:
-    #    print(nu_term2,nu_term3)
-
-    #explit calculation of Term3
-    #            dum = 0
-    #            for l in range(K):
-    #                if (l != k):
-    #                    dum += nu[n,l] * phi_mu[:,l]
-    #
-    #            nu_term3_alt = (1 / s_eps) * np.dot(phi_mu[:,k], X[n,:] - dum)
-    #
-    #            if np.abs(nu_term3 - nu_term3_alt)>10**(-10):
-    #                print(nu_term3-nu_term3_alt)
-    #                print('calculation of nu_term3 is off')
-    #                input('paused')
-
-
-    #if k==0 and n==0:
-    #    print(nu_term1, nu_term2, nu_term3)
 
     script_V = nu_term1 - nu_term2 + nu_term3
 
@@ -132,40 +94,12 @@ def compute_elbo(tau, nu, phi_mu, phi_var, X, sigmas, alpha):
     # bernoulli terms
     elbo_term1 = (alpha/K - 1) * np.sum( digamma_tau[:,0] - digamma_sum_tau[:] )
 
-#    elbo_term2 = 0.
-#    for k in range(K):
-#        for n in range(N):
-#            elbo_term2 = elbo_term2 + nu[n,k] * digamma_tau[k,0] + (1.-nu[n,k])*\
-#                    digamma_tau[k,1] - digamma_sum_tau[k]
-
     elbo_term2 = np.sum(np.dot(nu, digamma_tau[:,0]) + np.dot(1-nu, digamma_tau[:,1])) \
                 - N * np.sum(digamma_sum_tau)
-
-
-#    elbo_term3 = np.sum(\
-#        -D/2.*np.log(2.*np.pi*sigma_A) - 1./(2.*sigma_A) *\
-#        (phi_var[k]*D + \
-#        np.dot(phi_mu[:, k] , phi_mu[:, k])) for k in range(K) )
 
     elbo_term3 = \
         -K*D/2.*np.log(2.*np.pi*sigma_A) - 1./(2.*sigma_A) *\
         (np.sum(phi_var)*D + np.trace(np.dot(phi_mu.T , phi_mu)))
-
-
-#    elbo_term4 = 0.
-#
-#    for n in range(N):
-#        summ1 = np.sum(
-#            nu[n,k] * np.dot(phi_mu[:,k], X[n,:]) for k in range(K))
-#        summ2 = np.sum(
-#                np.sum(
-#                nu[n,k1] * nu[n,k2] * np.dot(phi_mu[:,k1], phi_mu[:,k2]) \
-#                for k1 in range(k2) ) for k2 in range(K))
-#        summ3 = np.sum(nu[n,k] * (D*phi_var[k] + \
-#            np.dot(phi_mu[:,k], phi_mu[:,k])) for k in range(K))
-
-#        elbo_term4 = elbo_term4 - D / 2. * np.log(2. * np.pi * sigma_eps) - \
-#           1. / (2. * sigma_eps) * (np.dot(X[n,:], X[n,:]) - 2. * summ1 + 2. * summ2 + summ3)
 
     elbo_term4 = \
         -N * D/2. * np.log(2. * np.pi * sigma_eps)\
@@ -175,23 +109,15 @@ def compute_elbo(tau, nu, phi_mu, phi_var, X, sigmas, alpha):
         -1/(2.*sigma_eps) * np.trace(np.dot(np.dot(nu, np.dot(phi_mu.T, phi_mu) - np.identity(K) \
                                                     * np.diag(np.dot(phi_mu.T, phi_mu))), nu.T))\
 
-
-    #log_beta = betaln(tau[:,0],tau[:,1]) # apparently this isn't in autograd.scipy
-
+    # The log beta function is not in autograd's scipy.
     log_beta = sp.special.gammaln(tau[:,0]) + sp.special.gammaln(tau[:,1]) \
         - sp.special.gammaln(tau[:,0] + tau[:,1])
-
-    # log_beta = np.log(\
-    #        (sp.special.gamma(tau[:,0]) * sp.special.gamma(tau[:,1]) )/\
-    #        sp.special.gamma(tau[:,0] + tau[:,1]) )
 
     elbo_term5 = np.sum(log_beta - \
         (tau[:,0] - 1) * digamma_tau[:,0] - \
         (tau[:,1] - 1) * digamma_tau[:,1] + \
         (tau[:,0] + tau[:,1] -2.) *  digamma_sum_tau[:])
 
-#    elbo_term6 = np.sum(1. / 2. * np.log((2. * np.pi * np.exp(1.)) ** D * \
-#        phi_var[k]**D) for k in range(K))
     elbo_term6 = np.sum(1. / 2. * np.log((2. * np.pi * np.exp(1.) * \
         phi_var)**D))
 
@@ -200,4 +126,59 @@ def compute_elbo(tau, nu, phi_mu, phi_var, X, sigmas, alpha):
     elbo = elbo_term1 + elbo_term2 + elbo_term3 + elbo_term4 + elbo_term5 + elbo_term6 + elbo_term7
 
     return(elbo, elbo_term1, elbo_term2, elbo_term3, elbo_term4, elbo_term5, elbo_term6, elbo_term7)
-    # return(elbo)
+
+
+def generate_data(Num_samples, D, K_inf, sigma_A, sigma_eps):
+    Pi = np.ones(K_inf) * .8
+    Z = np.zeros([Num_samples, K_inf])
+
+    # Parameters to draw A from MVN
+    mu = np.zeros(D)
+
+    # Draw Z from truncated stick breaking process
+    Z = np.random.binomial(1, Pi, [ Num_samples, K_inf ])
+
+    # Draw A from multivariate normal
+    A = np.random.multivariate_normal(mu, sigma_A * np.identity(D), K_inf)
+
+    # draw noise
+    epsilon = np.random.multivariate_normal(
+        np.zeros(D), sigma_eps*np.identity(D), Num_samples)
+
+    # the observed data
+    X = np.dot(Z,A) + epsilon
+
+    return Pi, Z, mu, A, X
+
+
+def initialize_parameters(Num_samples, D, K_approx):
+    tau = np.random.uniform(0, 1, [K_approx, 2]) # tau1, tau2 -- beta parameters for v
+    nu =  np.random.uniform(0, 1, [Num_samples, K_approx]) # Bernoulli parameter for z_nk
+
+    phi_mu = np.random.normal(0, 1, [D, K_approx]) # kth mean (D dim vector) in kth column
+    phi_var = np.ones(K_approx)
+
+    return tau, nu, phi_mu, phi_var
+
+
+def generate_data(Num_samples, D, K_inf, sigma_A, sigma_eps):
+    Pi = np.ones(K_inf) * .8
+    Z = np.zeros([Num_samples, K_inf])
+
+    # Parameters to draw A from MVN
+    mu = np.zeros(D)
+
+    # Draw Z from truncated stick breaking process
+    Z = np.random.binomial(1, Pi, [ Num_samples, K_inf ])
+
+    # Draw A from multivariate normal
+    A = np.random.multivariate_normal(mu, sigma_A * np.identity(D), K_inf)
+
+    # draw noise
+    epsilon = np.random.multivariate_normal(
+        np.zeros(D), sigma_eps*np.identity(D), Num_samples)
+
+    # the observed data
+    X = np.dot(Z,A) + epsilon
+
+    return Pi, Z, mu, A, X


### PR DESCRIPTION
Add wrappers to convert the BNP parameters to and from an unconstrained vector space.  Do a little bit of tidying.

Alarmingly, in python2, the cavi unit tests fail with incorrect updates!  I'm switching to python3, but it might be worth understanding that -- I can't think of any good reason that should occur.